### PR TITLE
Fix duplicate row bug in data collection

### DIFF
--- a/nhsbt_acquire/cli.py
+++ b/nhsbt_acquire/cli.py
@@ -35,7 +35,10 @@ def main():
         row = pandas.DataFrame(vals, index=[0])
         if os.path.exists(csv_file):
             df = pandas.read_csv(csv_file)
-            df = pandas.concat([df, row], ignore_index = True)
+            df = pandas.concat([df, row], ignore_index=True)
+            # If we already have an entry for this date replace it to avoid
+            # duplicated rows which can skew the charts.
+            df = df.drop_duplicates(subset=["date"], keep="last")
         else:
             df = row
         df.to_csv(csv_file, index=False)


### PR DESCRIPTION
## Summary
- deduplicate entries by date when scraping data to avoid duplicate rows

## Testing
- `python -m py_compile nhsbt_acquire/cli.py`

------
https://chatgpt.com/codex/tasks/task_e_684407b8eb88832a85b387b69ea1641c